### PR TITLE
chore(java 17): Compile with Java 17

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v3
       with:
-        java-version: 11
+        java-version: 17
         distribution: 'temurin'
         cache: 'maven'
 

--- a/.github/workflows/createRelease.yml
+++ b/.github/workflows/createRelease.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Release connector
-        uses: bonitasoft/action-release-connector@1.0.0
+        uses: bonitasoft/action-release-connector@2.0.0
         id: release-connector
         with:
           release-version: ${{ github.event.inputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ target
 *.iml
 .idea/
 *.DS_Store
+/bin/


### PR DESCRIPTION
Use version 2.0.0 of release action which compiles with Java 17

11 compatibility is needed for the connector to be compatible with maintenance versions