### PR TITLE
chore(deps): bump jakarta.mail from 1.6.7 to 1.6.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
         <email.main-class>org.bonitasoft.connectors.email.EmailConnector</email.main-class>
 
         <!-- Connector dependencies -->
-        <jakarta.mail.version>1.6.7</jakarta.mail.version>
+        <jakarta.mail.version>1.6.8</jakarta.mail.version>
 
         <!-- Bonita -->
         <bonita-runtime.version>8.0.0</bonita-runtime.version>


### PR DESCRIPTION
## Summary
- Bumps `com.sun.mail:jakarta.mail` (and matching API) from **1.6.7** to **1.6.8** (the latest 1.6.x patch).
- Addresses Pablo's review request from the Slack PR follow-up (engine-managed at runtime; this is the only release that ships the Jakarta Mail jars).

## Test plan
- [x] `mvn test` — 19/19 pass locally
- [ ] CI green