### PR TITLE
chore(rebranding): update bonitasoft.com domain references to ofelia.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,8 +162,8 @@ Key dependencies (managed in `pom.xml`):
 
 ## Additional Resources
 
-- [Bonita Documentation](https://documentation.bonitasoft.com)
-- [Bonita Connector Development Guide](https://documentation.bonitasoft.com/bonita/latest/software-extensibility/connectors)
+- [Bonita Documentation](https://documentation.ofelia.com)
+- [Bonita Connector Development Guide](https://documentation.ofelia.com/bonita/latest/software-extensibility/connectors)
 - [Jakarta Mail API Documentation](https://eclipse-ee4j.github.io/mail/)
 - [Project README](README.md)
 - [Contributing Guidelines](CONTRIBUTING.md)

--- a/XOAUTH2_TESTING.md
+++ b/XOAUTH2_TESTING.md
@@ -238,4 +238,4 @@ curl -X POST https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token \
 - [Microsoft OAuth2 SMTP Documentation](https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth)
 - [Google OAuth2 SMTP Documentation](https://developers.google.com/gmail/imap/xoauth2-protocol)
 - [JavaMail OAuth2 Support](https://javaee.github.io/javamail/OAuth2)
-- [Bonita Connector Development](https://documentation.bonitasoft.com/bonita/latest/software-extensibility/connectors)
+- [Bonita Connector Development](https://documentation.ofelia.com/bonita/latest/software-extensibility/connectors)

--- a/src/test/java/org/bonitasoft/connectors/email/EmailConnectorIT.java
+++ b/src/test/java/org/bonitasoft/connectors/email/EmailConnectorIT.java
@@ -377,7 +377,7 @@ class EmailConnectorIT {
         document.setHasContent(false);
         document.setId(1);
         document.setProcessInstanceId(1);
-        document.setUrl("http://www.bonitasoft.com");
+        document.setUrl("http://www.ofelia.com");
         document.setName("Document1");
         when(engineExecutionContext.getProcessInstanceId()).thenReturn(1L);
         when(processAPI.getLastDocument(1L, "Document1")).thenReturn(document);
@@ -394,7 +394,7 @@ class EmailConnectorIT {
 
         final Multipart part = (Multipart) messages[0].getContent();
         assertThat((String) part.getBodyPart(0).getContent())
-                .contains("http://www.bonitasoft.com");
+                .contains("http://www.ofelia.com");
     }
 
     @Test


### PR DESCRIPTION
Replace bonitasoft.com domain URLs with ofelia.com equivalents. No logic changes. Part of the Bonitasoft → Ofelia rebranding.